### PR TITLE
In the README, link to the design document, not the (currently useless) repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Build status](https://github.com/stepchowfun/gigamesh-schema/workflows/Continuous%20integration/badge.svg?branch=main)](https://github.com/stepchowfun/gigamesh-schema/actions?query=branch%3Amain)
 
-This project contains the [Typical](https://github.com/stepchowfun/typical) schema for the [Gigamesh](https://github.com/stepchowfun/gigamesh) data model.
+This project contains the [Typical](https://github.com/stepchowfun/typical) schema for the [Gigamesh](https://paper.dropbox.com/doc/Gigamesh-a-graph-for-all-your-stuff--BVVy3rPrxm0u8jXS9dlzTwXaAg-0bDn25maMdzznQSeYhUeW) data model.


### PR DESCRIPTION
In the README, link to the design document, not the (currently useless) repository.

**Status:** Ready

**Fixes:** N/A
